### PR TITLE
Updated melf dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aran-remote",
   "description": "Deploy local Aran advices on remote processes",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "author": {
     "name": "Laurent Christophe",
     "email": "lachrist@vub.ac.be"
@@ -13,7 +13,7 @@
     "acorn": "^6.1.0",
     "aran": "3.0.8",
     "astring": "^1.3.1",
-    "melf": "2.2.13",
+    "melf": "2.2.14",
     "melf-share": "0.1.12",
     "otiluke": "5.4.3"
   },


### PR DESCRIPTION
This is required for supporting current Node.js versions (due to melf->antena->posix-socket dependency)